### PR TITLE
Migrate to .NET Framework 4.8 and Visual Studio 2019

### DIFF
--- a/Application/Designers/AppXDesigner/App.config
+++ b/Application/Designers/AppXDesigner/App.config
@@ -12,4 +12,7 @@
       </setting>
     </AppXDesigner.Properties.Settings>
   </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+  </startup>
+</configuration>

--- a/Application/Designers/AppXDesigner/AppXDesigner.csproj
+++ b/Application/Designers/AppXDesigner/AppXDesigner.csproj
@@ -37,12 +37,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/Application/Designers/AppXDesigner/AppXDesigner.csproj
+++ b/Application/Designers/AppXDesigner/AppXDesigner.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AppXDesigner</RootNamespace>
     <AssemblyName>AppXDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/AppXDesigner/AppXDesigner.csproj
+++ b/Application/Designers/AppXDesigner/AppXDesigner.csproj
@@ -108,7 +108,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -122,6 +121,11 @@
       <Project>{461ddab2-0b76-460d-9f3e-041cb88df974}</Project>
       <Name>IsWiXAutomationInterface</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Application/Designers/AppXDesigner/Properties/Resources.Designer.cs
+++ b/Application/Designers/AppXDesigner/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace AppXDesigner.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Application/Designers/AppXDesigner/Properties/Settings.Designer.cs
+++ b/Application/Designers/AppXDesigner/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AppXDesigner.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Application/Designers/AppXDesigner/packages.config
+++ b/Application/Designers/AppXDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/CustomTablesDesigner/CustomTablesDesigner.csproj
+++ b/Application/Designers/CustomTablesDesigner/CustomTablesDesigner.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/Application/Designers/CustomTablesDesigner/CustomTablesDesigner.csproj
+++ b/Application/Designers/CustomTablesDesigner/CustomTablesDesigner.csproj
@@ -132,7 +132,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Application/Designers/CustomTablesDesigner/CustomTablesDesigner.csproj
+++ b/Application/Designers/CustomTablesDesigner/CustomTablesDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CustomTablesDesigner</RootNamespace>
     <AssemblyName>CustomTablesDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/CustomTablesDesigner/packages.config
+++ b/Application/Designers/CustomTablesDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/FeaturesDesigner/FeaturesDesigner.csproj
+++ b/Application/Designers/FeaturesDesigner/FeaturesDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FeaturesDesigner</RootNamespace>
     <AssemblyName>FeaturesDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/FeaturesDesigner/FeaturesDesigner.csproj
+++ b/Application/Designers/FeaturesDesigner/FeaturesDesigner.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -128,7 +122,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Application/Designers/FeaturesDesigner/packages.config
+++ b/Application/Designers/FeaturesDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/FilesAndFoldersDesigner/FilesAndFoldersDesigner.csproj
+++ b/Application/Designers/FilesAndFoldersDesigner/FilesAndFoldersDesigner.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/Application/Designers/FilesAndFoldersDesigner/FilesAndFoldersDesigner.csproj
+++ b/Application/Designers/FilesAndFoldersDesigner/FilesAndFoldersDesigner.csproj
@@ -138,7 +138,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Application/Designers/FilesAndFoldersDesigner/FilesAndFoldersDesigner.csproj
+++ b/Application/Designers/FilesAndFoldersDesigner/FilesAndFoldersDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FilesAndFoldersDesigner</RootNamespace>
     <AssemblyName>FilesAndFoldersDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/FilesAndFoldersDesigner/Properties/Resources.Designer.cs
+++ b/Application/Designers/FilesAndFoldersDesigner/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace FilesAndFoldersDesigner.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Application/Designers/FilesAndFoldersDesigner/packages.config
+++ b/Application/Designers/FilesAndFoldersDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/GeneralInformationDesigner/GeneralInformationDesigner.csproj
+++ b/Application/Designers/GeneralInformationDesigner/GeneralInformationDesigner.csproj
@@ -82,21 +82,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.5.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Extended.Wpf.Toolkit.3.5.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.5.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Extended.Wpf.Toolkit.3.5.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.5.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Extended.Wpf.Toolkit.3.5.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.5.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Extended.Wpf.Toolkit.3.5.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
-    </Reference>
-    <Reference Include="Xceed.Wpf.Toolkit, Version=3.5.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Extended.Wpf.Toolkit.3.5.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models\DependencyModel.cs" />
@@ -157,6 +142,9 @@
     </PackageReference>
     <PackageReference Include="wix-libs">
       <Version>3.11.1</Version>
+    </PackageReference>
+    <PackageReference Include="Extended.Wpf.Toolkit">
+      <Version>3.5.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Application/Designers/GeneralInformationDesigner/GeneralInformationDesigner.csproj
+++ b/Application/Designers/GeneralInformationDesigner/GeneralInformationDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GeneralInformationDesigner</RootNamespace>
     <AssemblyName>GeneralInformationDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/GeneralInformationDesigner/GeneralInformationDesigner.csproj
+++ b/Application/Designers/GeneralInformationDesigner/GeneralInformationDesigner.csproj
@@ -63,24 +63,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Deployment.Compression, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\wix-libs.3.11.1\lib\net20\Microsoft.Deployment.Compression.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Deployment.Compression.Cab, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\wix-libs.3.11.1\lib\net20\Microsoft.Deployment.Compression.Cab.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Deployment.WindowsInstaller, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\wix-libs.3.11.1\lib\net20\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Deployment.WindowsInstaller.Package, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\wix-libs.3.11.1\lib\net20\Microsoft.Deployment.WindowsInstaller.Package.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -129,7 +111,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="Properties\DataSources\ModuleDependency.datasource" />
   </ItemGroup>
   <ItemGroup>
@@ -166,6 +147,17 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Extended.Wpf.Toolkit">
+      <Version>3.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
+    <PackageReference Include="wix-libs">
+      <Version>3.11.1</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Application/Designers/GeneralInformationDesigner/packages.config
+++ b/Application/Designers/GeneralInformationDesigner/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="Extended.Wpf.Toolkit" version="3.5.0" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-  <package id="wix-libs" version="3.11.1" targetFramework="net462" />
-</packages>

--- a/Application/Designers/MSIXDesigner/App.config
+++ b/Application/Designers/MSIXDesigner/App.config
@@ -12,4 +12,7 @@
       </setting>
     </MSIXDesigner.Properties.Settings>
   </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+  </startup>
+</configuration>

--- a/Application/Designers/MSIXDesigner/MSIXDesigner.csproj
+++ b/Application/Designers/MSIXDesigner/MSIXDesigner.csproj
@@ -37,12 +37,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/Application/Designers/MSIXDesigner/MSIXDesigner.csproj
+++ b/Application/Designers/MSIXDesigner/MSIXDesigner.csproj
@@ -109,7 +109,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -123,6 +122,11 @@
       <Project>{461ddab2-0b76-460d-9f3e-041cb88df974}</Project>
       <Name>IsWiXAutomationInterface</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Application/Designers/MSIXDesigner/MSIXDesigner.csproj
+++ b/Application/Designers/MSIXDesigner/MSIXDesigner.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MSIXDesigner</RootNamespace>
     <AssemblyName>MSIXDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/MSIXDesigner/Properties/Resources.Designer.cs
+++ b/Application/Designers/MSIXDesigner/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace MSIXDesigner.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Application/Designers/MSIXDesigner/Properties/Settings.Designer.cs
+++ b/Application/Designers/MSIXDesigner/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MSIXDesigner.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Application/Designers/MSIXDesigner/packages.config
+++ b/Application/Designers/MSIXDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/NamespacesDesigner/NamespacesDesigner.csproj
+++ b/Application/Designers/NamespacesDesigner/NamespacesDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NamespacesDesigner</RootNamespace>
     <AssemblyName>NamespacesDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/NamespacesDesigner/NamespacesDesigner.csproj
+++ b/Application/Designers/NamespacesDesigner/NamespacesDesigner.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -100,9 +94,6 @@
     <EmbeddedResource Include="Namespaces.ico" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
       <Visible>False</Visible>
       <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
@@ -124,6 +115,11 @@
       <Project>{461ddab2-0b76-460d-9f3e-041cb88df974}</Project>
       <Name>IsWiXAutomationInterface</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="Views\NamespacesView.xaml">

--- a/Application/Designers/NamespacesDesigner/packages.config
+++ b/Application/Designers/NamespacesDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/PropertiesDesigner/PropertiesDesigner.csproj
+++ b/Application/Designers/PropertiesDesigner/PropertiesDesigner.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/Application/Designers/PropertiesDesigner/PropertiesDesigner.csproj
+++ b/Application/Designers/PropertiesDesigner/PropertiesDesigner.csproj
@@ -96,9 +96,6 @@
     <EmbeddedResource Include="License.txt" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Properties.ico" />
   </ItemGroup>
   <ItemGroup>
@@ -130,7 +127,11 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Application/Designers/PropertiesDesigner/PropertiesDesigner.csproj
+++ b/Application/Designers/PropertiesDesigner/PropertiesDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PropertiesDesigner</RootNamespace>
     <AssemblyName>PropertiesDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/PropertiesDesigner/packages.config
+++ b/Application/Designers/PropertiesDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/ServicesDesigner/ServicesDesigner.csproj
+++ b/Application/Designers/ServicesDesigner/ServicesDesigner.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/Application/Designers/ServicesDesigner/ServicesDesigner.csproj
+++ b/Application/Designers/ServicesDesigner/ServicesDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ServicesDesigner</RootNamespace>
     <AssemblyName>ServicesDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/ServicesDesigner/ServicesDesigner.csproj
+++ b/Application/Designers/ServicesDesigner/ServicesDesigner.csproj
@@ -135,7 +135,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Application/Designers/ServicesDesigner/packages.config
+++ b/Application/Designers/ServicesDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/Designers/ShortCutsDesigner/Properties/Resources.Designer.cs
+++ b/Application/Designers/ShortCutsDesigner/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ShortCutsDesigner.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Application/Designers/ShortCutsDesigner/ShortCutsDesigner.csproj
+++ b/Application/Designers/ShortCutsDesigner/ShortCutsDesigner.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/Application/Designers/ShortCutsDesigner/ShortCutsDesigner.csproj
+++ b/Application/Designers/ShortCutsDesigner/ShortCutsDesigner.csproj
@@ -143,7 +143,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Application/Designers/ShortCutsDesigner/ShortCutsDesigner.csproj
+++ b/Application/Designers/ShortCutsDesigner/ShortCutsDesigner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ShortCutsDesigner</RootNamespace>
     <AssemblyName>ShortCutsDesigner</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Designers/ShortCutsDesigner/packages.config
+++ b/Application/Designers/ShortCutsDesigner/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>

--- a/Application/IsWiX/IsWiX.csproj
+++ b/Application/IsWiX/IsWiX.csproj
@@ -63,15 +63,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="ICSharpCode.AvalonEdit, Version=5.0.3.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
-      <HintPath>..\packages\AvalonEdit.5.0.4\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -82,9 +73,6 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
-    <Reference Include="XmlEditorDesigner, Version=5.1.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\xmldesigner.5.1.4\lib\net40\XmlEditorDesigner.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">
@@ -257,9 +245,6 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -332,6 +317,14 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
+    <PackageReference Include="xmldesigner">
+      <Version>5.1.4</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Application/IsWiX/IsWiX.csproj
+++ b/Application/IsWiX/IsWiX.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IsWiX</RootNamespace>
     <AssemblyName>IsWiX</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/IsWiX/app.config
+++ b/Application/IsWiX/app.config
@@ -1,3 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+  </startup>
+</configuration>

--- a/Application/IsWiX/packages.config
+++ b/Application/IsWiX/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AvalonEdit" version="5.0.4" targetFramework="net462" />
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-  <package id="xmldesigner" version="5.1.4" targetFramework="net462" />
-</packages>

--- a/Application/Shared/WiXAutomationInteface/IsWiXAutomationInterface.csproj
+++ b/Application/Shared/WiXAutomationInteface/IsWiXAutomationInterface.csproj
@@ -59,12 +59,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiffPlex, Version=1.4.3.0, Culture=neutral, PublicKeyToken=1d35e91d1bd7bc0f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DiffPlex.1.4.3\lib\net40\DiffPlex.dll</HintPath>
-    </Reference>
-    <Reference Include="FireworksFramework, Version=5.1.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fireworks.5.1.13\lib\net40\FireworksFramework.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Deployment.WindowsInstaller">
       <HintPath>..\..\..\..\ExternalAssemblies\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
     </Reference>

--- a/Application/Shared/WiXAutomationInteface/IsWiXAutomationInterface.csproj
+++ b/Application/Shared/WiXAutomationInteface/IsWiXAutomationInterface.csproj
@@ -118,7 +118,9 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="fireworks">
+      <Version>5.1.13</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Application/Shared/WiXAutomationInteface/IsWiXAutomationInterface.csproj
+++ b/Application/Shared/WiXAutomationInteface/IsWiXAutomationInterface.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IsWiXAutomationInterface</RootNamespace>
     <AssemblyName>IsWiXAutomationInterface</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/Application/Shared/WiXAutomationInteface/packages.config
+++ b/Application/Shared/WiXAutomationInteface/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DiffPlex" version="1.4.3" targetFramework="net462" />
-  <package id="fireworks" version="5.1.13" targetFramework="net462" />
-</packages>


### PR DESCRIPTION
Does mostly what the title says. Note that while this change requires VS2019 to _build_ IsWIX, it does not require VS2019 to _run_ IsWIX. However, .NET Framework 4.8 must be installed first. (However, it is now being automatically offered via Windows Update. This shouldn't be very much of a problem.)

I also took the opportunity to migrate the NuGet package references to the newer, more flexible PackageReference format. This does not interfere with Visual Studio in any way (the NuGet GUI can still be used, and referenced assemblies are shown in IntelliSense just as before). Thanks!